### PR TITLE
Perf + cleanup: gate three.js to non-blog desktop, consolidate fonts

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import { Component, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component, ElementRef, ViewChild, AfterViewInit, OnDestroy } from '@angular/core';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
+import { Subscription, filter } from 'rxjs';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -19,17 +20,68 @@ import { MatIconModule } from '@angular/material/icon';
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
-export class AppComponent implements AfterViewInit {
+export class AppComponent implements AfterViewInit, OnDestroy {
   @ViewChild('bgContainer') bgContainer!: ElementRef;
   title = 'unycross-llc';
 
-  constructor(private cyberpunkService: CyberpunkBackgroundService) {}
+  private routerSub?: Subscription;
+  private mobileMql = window.matchMedia('(max-width: 760px)');
+  private mobileListener = () => this.applyBackgroundForCurrentRoute();
+
+  constructor(
+    private cyberpunkService: CyberpunkBackgroundService,
+    private router: Router,
+  ) {}
 
   ngAfterViewInit() {
-    this.cyberpunkService.initBackground(this.bgContainer.nativeElement);
+    this.cyberpunkService.attach(this.bgContainer.nativeElement);
+    this.applyBackgroundForCurrentRoute();
+
+    this.routerSub = this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe(() => this.applyBackgroundForCurrentRoute());
+
+    // Re-evaluate when the viewport crosses the mobile breakpoint (rotation,
+    // window resize, devtools toggle). addEventListener form is supported on
+    // every evergreen browser; addListener is the older polyfill path.
+    if (typeof this.mobileMql.addEventListener === 'function') {
+      this.mobileMql.addEventListener('change', this.mobileListener);
+    } else {
+      this.mobileMql.addListener(this.mobileListener);
+    }
+  }
+
+  ngOnDestroy() {
+    this.routerSub?.unsubscribe();
+    if (typeof this.mobileMql.removeEventListener === 'function') {
+      this.mobileMql.removeEventListener('change', this.mobileListener);
+    } else {
+      this.mobileMql.removeListener(this.mobileListener);
+    }
+    this.cyberpunkService.stop();
   }
 
   scrollToTop() {
     window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  /**
+   * The cyberpunk three.js scene runs only on desktop, on routes where it
+   * doesn't compete with reading content. The blog routes get a calmer
+   * background so long-form posts don't flicker behind 2000 particles, and
+   * mobile gets the static scanline overlay alone (saving battery + frame
+   * budget).
+   */
+  private applyBackgroundForCurrentRoute(): void {
+    const url = this.router.url;
+    const onBlog = url === '/blog' || url.startsWith('/blog/');
+    const onMobile = this.mobileMql.matches;
+    const shouldRun = !onBlog && !onMobile;
+
+    if (shouldRun && !this.cyberpunkService.isActive()) {
+      this.cyberpunkService.start();
+    } else if (!shouldRun && this.cyberpunkService.isActive()) {
+      this.cyberpunkService.stop();
+    }
   }
 }

--- a/src/app/shared/cyberpunk-background.service.ts
+++ b/src/app/shared/cyberpunk-background.service.ts
@@ -1,4 +1,3 @@
-// src/app/services/cyberpunk-background.service.ts
 import { Injectable } from '@angular/core';
 import { CyberpunkBackground } from '../utils/cyberpunk-bg';
 
@@ -7,8 +6,28 @@ import { CyberpunkBackground } from '../utils/cyberpunk-bg';
 })
 export class CyberpunkBackgroundService {
   private background: CyberpunkBackground | null = null;
+  private container: HTMLElement | null = null;
 
-  initBackground(container: HTMLElement) {
-    this.background = new CyberpunkBackground(container);
+  /** Bind a host container; the service will mount/unmount the canvas inside it. */
+  attach(container: HTMLElement): void {
+    this.container = container;
+  }
+
+  /** Mount the cyberpunk canvas into the attached container. No-op if already mounted. */
+  start(): void {
+    if (this.background || !this.container) return;
+    this.background = new CyberpunkBackground(this.container);
+  }
+
+  /** Tear down the canvas and animation loop. No-op if not mounted. */
+  stop(): void {
+    if (!this.background) return;
+    this.background.dispose();
+    this.background = null;
+  }
+
+  /** Whether the background is currently mounted. */
+  isActive(): boolean {
+    return this.background !== null;
   }
 }

--- a/src/app/utils/cyberpunk-bg.ts
+++ b/src/app/utils/cyberpunk-bg.ts
@@ -32,6 +32,12 @@ export class CyberpunkBackground {
   private clock: THREE.Clock;
   private mouse: THREE.Vector2;
   private particleTexture: THREE.Texture;
+  private animationFrameId: number | null = null;
+  private disposed = false;
+  private boundResize = () => this.onWindowResize();
+  private boundMouseMove = (e: MouseEvent) => this.onMouseMove(e);
+  private boundTouchMove = (e: TouchEvent) => this.onTouchMove(e);
+  private boundScroll = () => this.onWindowScroll();
 
   constructor(container?: string | HTMLElement) {
     if (typeof container === 'string') {
@@ -130,11 +136,11 @@ export class CyberpunkBackground {
 
     this.container.appendChild(this.renderer.domElement);
 
-    // Add event listeners
-    window.addEventListener('resize', this.onWindowResize.bind(this));
-    window.addEventListener('mousemove', this.onMouseMove.bind(this));
-    window.addEventListener('touchmove', this.onTouchMove.bind(this));
-    window.addEventListener('scroll', this.onWindowScroll.bind(this));
+    // Add event listeners (bound refs stored so dispose() can remove them)
+    window.addEventListener('resize', this.boundResize);
+    window.addEventListener('mousemove', this.boundMouseMove);
+    window.addEventListener('touchmove', this.boundTouchMove);
+    window.addEventListener('scroll', this.boundScroll);
 
     // Create elements
     this.createStars();
@@ -251,7 +257,8 @@ export class CyberpunkBackground {
   }
 
   private animate(): void {
-    requestAnimationFrame(this.animate.bind(this));
+    if (this.disposed) return;
+    this.animationFrameId = requestAnimationFrame(this.animate.bind(this));
 
     const delta = this.clock.getDelta();
     const elapsedTime = this.clock.getElapsedTime();
@@ -402,6 +409,36 @@ export class CyberpunkBackground {
       this.camera.position.x = this.mouse.x * 3; // Reduced movement
       this.camera.position.y = this.mouse.y * 3 + 10; // Reduced movement
       this.camera.lookAt(0, 0, 0);
+    }
+  }
+
+  // Tear everything down: cancel the rAF loop, remove window listeners,
+  // dispose the renderer, and detach the canvas. Called when the route
+  // moves to a page that should not render the background (or on mobile).
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    if (this.animationFrameId !== null) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+
+    window.removeEventListener('resize', this.boundResize);
+    window.removeEventListener('mousemove', this.boundMouseMove);
+    window.removeEventListener('touchmove', this.boundTouchMove);
+    window.removeEventListener('scroll', this.boundScroll);
+
+    if (this.renderer) {
+      this.renderer.dispose();
+      const canvas = this.renderer.domElement;
+      if (canvas && canvas.parentNode) {
+        canvas.parentNode.removeChild(canvas);
+      }
+    }
+
+    if (this.particleTexture) {
+      this.particleTexture.dispose();
     }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -95,26 +95,29 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <!-- Preconnect first so the font CSS + WOFF requests negotiate sockets in parallel -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+
+    <!-- All four Google font families in a single request -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Audiowide&family=Orbitron:wght@400;500;700&family=Rajdhani:wght@300;400;500;700&family=Material+Icons&display=swap"
+    />
+
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      media="print"
+      onload="this.media='all'; this.onload=null;"
     />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Audiowide&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
-      rel="stylesheet"
-    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      />
+    </noscript>
   </head>
   <body>
     <app-root></app-root>


### PR DESCRIPTION
## Summary

Closes audit items 5, 6, 8.

## three.js gating (item 5)

Previously the cyberpunk particle scene ran on every route, including the blog (where it competes with reading) and on mobile (where 2000 particles tax the frame budget for no UX benefit).

- `CyberpunkBackground.dispose()` now cancels the rAF loop, removes the four window listeners (resize / mousemove / touchmove / scroll), and tears down the WebGL renderer + canvas DOM node.
- `CyberpunkBackgroundService` is now `attach()` / `start()` / `stop()` so the host can swap state at runtime.
- `AppComponent` listens to `NavigationEnd` and a `(max-width: 760px)` matchMedia. The scene runs only on **desktop** and only on **non-blog** routes. Mobile + blog readers see the existing static scanline overlay alone.

## Font consolidation (item 8)

`index.html` previously made four separate Google Fonts requests, plus FontAwesome from cdnjs, all render-blocking, with no preconnect.

- Single Google Fonts CSS request now covers Audiowide + Orbitron + Rajdhani + Material Icons.
- `preconnect` to `fonts.googleapis.com`, `fonts.gstatic.com`, and `cdnjs.cloudflare.com` so the WOFF requests negotiate sockets in parallel.
- FontAwesome loads async via the `media="print"` → `media="all"` swap pattern with a `<noscript>` fallback.

## Cleanup (item 6)

Empty `src/app/pages/ai-concepts/` folder removed (was untracked in git, just on disk).

## Test plan

- [ ] `ng build` passes (verified locally — clean)
- [ ] On desktop, navigate `/` → `/blog` → `/about`: cyberpunk scene unmounts on `/blog`, remounts on `/about`. WebGL canvas absent in the DOM during `/blog`.
- [ ] On mobile (or DevTools narrow viewport), no WebGL canvas at any route.
- [ ] Resize from 1200px to 600px: scene tears down. Resize back: scene remounts (assuming non-blog route).
- [ ] Lighthouse on `/blog` shows lower TBT/FID after deploy (no rAF loop, no WebGL context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)