### PR TITLE
Fix: blog page falls back to white when three.js disposes

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -107,7 +107,10 @@ $text-color-5: #ab47bc; // Vibrant purple
 
 // Global styles
 body {
-  // background: $background-color;
+  // The dark base must be on the body itself so routes that don't render the
+  // three.js cyberpunk canvas (blog, mobile) still get the cyberpunk dark
+  // backdrop instead of falling through to browser-default white.
+  background: $background-color;
   color: $text-color-1;
   line-height: 1.6;
   margin: 0;


### PR DESCRIPTION
## Summary

PR #6 broke the blog page background. Spotted on review: the body had no explicit background-color (the rule was commented out in `styles.scss`), so the cyberpunk three.js canvas was the only thing providing the dark backdrop. Once PR #6 started disposing the canvas on `/blog` and on mobile, the body fell through to browser-default white — making the transparent-until-scrolled header invisible (cyan logo + white nav text on white) and the back-to-top spinner stand out awkwardly.

## Fix

One line: uncomment `body { background: \$background-color; }` in `styles.scss`. The dark base is now on the body unconditionally; three.js becomes a particle layer *on top* rather than the only source of the dark color.

## Test plan

- [x] `ng build` clean
- [ ] After deploy: navigate to `/blog`, header visible at top of page (cyan logo, white nav text on dark backdrop)
- [ ] Resize to mobile width on home: dark background still there, no flash to white
- [ ] Back-to-top spinner reads correctly on `/blog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)