### PR TITLE
blog: rewrite hero lede to describe Nova

### DIFF
--- a/src/app/pages/blog/blog-list/blog-list.component.html
+++ b/src/app/pages/blog/blog-list/blog-list.component.html
@@ -3,9 +3,16 @@
     <p class="eyebrow accent-text" [@fadeIn]="state">Dev Log</p>
     <h1 [@fadeIn]="state">Building Nova</h1>
     <p class="lede" [@fadeIn]="state">
-      A logbook for the Jarvis-inspired desktop AI assistant I'm building for myself —
-      decisions, dead-ends, and the occasional war story. Voice, brain-swap, skills,
-      a stock screener, a few production-week disasters, and counting.
+      Nova is the Jarvis-style desktop AI I'm building for myself —
+      voice-first, multi-brain, skill-pluggable, Obsidian-backed memory.
+      The investing surface is where she earns her keep: a multi-confluence
+      stock screener, an autonomous AI Picks pipeline that ranks the market
+      for around seven cents a run, a TradingView-style Lookup panel, and a
+      Smart Money tab surfacing insider buys live — with congressional
+      trades, options flow, and billionaire positioning queued up next.
+      Calendar, CRM, chat, and the voice agent all still work too; that's
+      the platform underneath. This is the logbook of how she got here and
+      where she's heading.
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Summary

Hero lede previously framed the page as 'a logbook' before saying anything about Nova herself. Rewritten to lead with what Nova is, prioritize the investing surface (screener / AI Picks / Lookup / Smart Money), tee up what's queued next (Congress trades, options flow, billionaire positioning), and acknowledge the rest of the platform (calendar, CRM, voice, chat) without burying it.

## Test plan

- [x] \`ng build\` clean
- [ ] After deploy, hero lede on /blog reads coherently and wraps to ~5 lines on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)