### PR TITLE
blog: lede rewrite v2 — Luke's voice, user value over stack

### DIFF
--- a/src/app/pages/blog/blog-list/blog-list.component.html
+++ b/src/app/pages/blog/blog-list/blog-list.component.html
@@ -3,16 +3,16 @@
     <p class="eyebrow accent-text" [@fadeIn]="state">Dev Log</p>
     <h1 [@fadeIn]="state">Building Nova</h1>
     <p class="lede" [@fadeIn]="state">
-      Nova is the Jarvis-style desktop AI I'm building for myself —
-      voice-first, multi-brain, skill-pluggable, Obsidian-backed memory.
-      The investing surface is where she earns her keep: a multi-confluence
-      stock screener, an autonomous AI Picks pipeline that ranks the market
-      for around seven cents a run, a TradingView-style Lookup panel, and a
-      Smart Money tab surfacing insider buys live — with congressional
-      trades, options flow, and billionaire positioning queued up next.
-      Calendar, CRM, chat, and the voice agent all still work too; that's
-      the platform underneath. This is the logbook of how she got here and
-      where she's heading.
+      Nova is my Jarvis — a trading copilot I built into my desktop,
+      catered to exactly how I work. She finds opportunities in the
+      market, keeps me on top of my businesses, and has a sense of humor.
+      The honest version: she's the tool that finally tied my profession
+      to my passion. I write software for a living and trade for the love
+      of it; Nova is what happens when those two collide. She's slowly
+      becoming the best stock-investing tool I have access to — and the
+      engine I'm using to scale my Leaving The Matrix investing education
+      business. Calendar, CRM, and notes are on the roadmap; for now, the
+      trading suite is where she earns her keep.
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Summary

Second pass at the blog hero lede. The previous version (PR #8) still leaned on stack vocabulary ('multi-brain', 'Obsidian-backed', 'skill-pluggable') that's not really how Luke describes Nova when asked. Rewrote it from his own answers:

- 'my Jarvis... a trading copilot' as the elevator pitch (verbatim)
- The 'tied my profession to my passion' angle (the part Luke said he was most excited about)
- LTM gets a name-drop because that business is what makes Nova load-bearing
- Calendar/CRM/notes acknowledged as roadmap, not pretended to be in active use

🤖 Generated with [Claude Code](https://claude.com/claude-code)