### PR TITLE
Fix: grey dotted rectangle on mobile hero sections

### DIFF
--- a/src/app/pages/about/about.component.scss
+++ b/src/app/pages/about/about.component.scss
@@ -7,19 +7,21 @@
   color: #ffffff;
   overflow: hidden;
 
+  // CSS-only soft radial glow — works on or off the three.js canvas.
+  // See home.component.scss for the full reasoning.
   &::after {
     content: "";
     position: absolute;
     inset: 0;
     z-index: -99999;
-    backdrop-filter: blur(1em) brightness(6);
-    background-image: radial-gradient(
-      circle at 50% 50%,
-      #0000 0,
-      #0000 2px,
-      hsl(0 0 4%) 2px
+    background: radial-gradient(
+      ellipse at center,
+      rgba(187, 134, 252, 0.20) 0%,
+      rgba(107, 64, 160, 0.10) 35%,
+      rgba(0, 217, 255, 0.05) 65%,
+      transparent 90%
     );
-    background-size: 8px 8px;
+    pointer-events: none;
   }
 
   .container {

--- a/src/app/pages/contact/contact.component.scss
+++ b/src/app/pages/contact/contact.component.scss
@@ -9,19 +9,21 @@
   padding: 2rem;
   position: relative;
 
+  // CSS-only soft radial glow — works on or off the three.js canvas.
+  // See home.component.scss for the full reasoning.
   &::after {
     content: "";
     position: absolute;
     inset: 0;
     z-index: -99999;
-    backdrop-filter: blur(1em) brightness(6);
-    background-image: radial-gradient(
-      circle at 50% 50%,
-      #0000 0,
-      #0000 2px,
-      hsl(0 0 4%) 2px
+    background: radial-gradient(
+      ellipse at center,
+      rgba(187, 134, 252, 0.20) 0%,
+      rgba(107, 64, 160, 0.10) 35%,
+      rgba(0, 217, 255, 0.05) 65%,
+      transparent 90%
     );
-    background-size: 8px 8px;
+    pointer-events: none;
   }
 
   h1 {

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -60,12 +60,24 @@
   }
 }
 
+// Hero glow — a CSS-only soft radial gradient that reads correctly on or off
+// the three.js canvas. The previous version used `backdrop-filter: blur brightness(6)`
+// plus a dot-grid background, both of which only worked because the WebGL canvas
+// covered them on desktop; once the canvas got gated off on mobile/blog they
+// became visible as a brightened grey rectangle with a halftone dot pattern.
 .hero-bg::after {
   content: "";
   position: absolute;
   inset: 0;
   z-index: -99999;
-  backdrop-filter: blur(1em) brightness(6);
+  background: radial-gradient(
+    ellipse at center,
+    rgba(187, 134, 252, 0.20) 0%,
+    rgba(107, 64, 160, 0.10) 35%,
+    rgba(0, 217, 255, 0.05) 65%,
+    transparent 90%
+  );
+  pointer-events: none;
 }
 
 .hero-bg {


### PR DESCRIPTION
## Summary

PR #6 disposed the three.js canvas on mobile. That exposed two side-effects on the home, about, and contact hero ::after pseudo-elements that had been hidden by the canvas all along:

- \`backdrop-filter: blur(1em) brightness(6)\` — multiplied the dark body bg by 6, producing a solid grey rectangle.
- \`background-image: radial-gradient(...) 8px 8px\` — an 8px-tile halftone dot-grid that became visible as the textured pattern overlay.

Replaced both with a single soft CSS radial gradient (purple → cyan → transparent). It's invisible under the three.js canvas on desktop (where it always was) and renders as a clean ambient glow on mobile and on \`/blog\` where the canvas isn't running.

## Test plan

- [x] \`ng build\` passes
- [ ] Mobile: \`/\`, \`/about\`, \`/contact\` hero sections render with a soft purple/cyan glow on the dark body — no grey rectangle, no dot grid
- [ ] Desktop: hero sections look identical to before (canvas still covers the pseudo)
- [ ] /blog mobile: still uses the simple dark body bg from PR #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)